### PR TITLE
Enable interactive input for glint ui

### DIFF
--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -43,16 +43,13 @@ func (ui *glintUI) Input(input *Input) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	text, _ := reader.ReadString('\n')
 	// convert CRLF to LF
-	text = strings.Replace(text, "\n", "", -1)
+	text = strings.TrimSpace(text)
 
 	return text, nil
 }
 
 // Interactive implements UI
 func (ui *glintUI) Interactive() bool {
-	// TODO(mitchellh): We can make this interactive later but Glint itself
-	// doesn't support input yet. We can pause the document, do some input,
-	// then resume potentially.
 	return true
 }
 
@@ -118,6 +115,7 @@ func (ui *glintUI) Output(msg string, raw ...interface{}) {
 			cs...,
 		),
 	))
+	ui.d.RenderFrame()
 }
 
 // NamedValues implements UI


### PR DESCRIPTION
This enables the glint terminal UI to have interactive user input. A plugin can use this like so:

```
func (c *Interactive) Execute(trm terminal.UI) int64 {
	output, err := trm.Input(&terminal.Input{Prompt: "\nWhat do you have to say"})
	if err != nil {
		trm.Output(err.Error())
		return 1
	}
	trm.Output("Did you say " + output)
	return 0
}
```