### PR TITLE
Avoid appending nil values to a terminal output message

### DIFF
--- a/terminal/ui.go
+++ b/terminal/ui.go
@@ -111,8 +111,10 @@ func Interpret(msg string, raw ...interface{}) (string, string, io.Writer) {
 		}
 	}
 
-	// Build our message
-	msg = fmt.Sprintf(msg, args...)
+	if args != nil {
+		// Build our message
+		msg = fmt.Sprintf(msg, args...)
+	}
 
 	// Build our config and set our options
 	cfg := &config{Writer: color.Output}


### PR DESCRIPTION
Before this change the output looked like
```
Progress: 10%!(NOVERB)
Progress: 20%!(NOVERB)
Progress: 30%!(NOVERB)
Progress: 40%!(NOVERB)
```

Now, the output looks like
```
Progress: 10%
Progress: 20%
Progress: 40%
Progress: 50%
Progress: 60%
Progress: 90%
```