### PR TITLE
Pass statebag to host detect function

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -8,7 +8,7 @@ type Host interface {
 	// Config() interface{}
 	// Documentation() (*docs.Documentation, error)
 	Capability(name string, args ...interface{}) (interface{}, error)
-	Detect() (bool, error)
+	Detect(state StateBag) (bool, error)
 	HasCapability(name string) (bool, error)
 	Parents() ([]string, error)
 

--- a/internal/plugin/host.go
+++ b/internal/plugin/host.go
@@ -107,10 +107,11 @@ func (c *hostClient) HostDetectFunc() interface{} {
 	return c.generateFunc(spec, cb)
 }
 
-func (c *hostClient) Detect() (bool, error) {
+func (c *hostClient) Detect(statebag core.StateBag) (bool, error) {
 	f := c.HostDetectFunc()
 	raw, err := c.callDynamicFunc(f, (*bool)(nil),
 		argmapper.Typed(c.ctx),
+		argmapper.Typed(statebag),
 	)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
This allows the Host detect function to accept a Statebag as an argument