### PR TITLE
Customize function name for argmapper Funcs

### DIFF
--- a/internal/funcspec/any_conv.go
+++ b/internal/funcspec/any_conv.go
@@ -1,6 +1,7 @@
 package funcspec
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/golang/protobuf/proto"
@@ -45,5 +46,6 @@ func anyConvGen(v argmapper.Value) (*argmapper.Func, error) {
 
 		outputSet.Typed(anyType).Value = reflect.ValueOf(anyVal)
 		return nil
-	})
+	}, argmapper.FuncName(fmt.Sprintf("converter: %s -> *anypb.Any", v.Type)))
+
 }

--- a/internal/funcspec/func.go
+++ b/internal/funcspec/func.go
@@ -19,7 +19,8 @@ func Func(s *vagrant_plugin_sdk.FuncSpec, cb interface{}, args ...argmapper.Arg)
 	// Build a Func around our callback so that we can inspect the
 	// input/output sets since we want to merge with that.
 	cbFunc, err := argmapper.NewFunc(cb,
-		argmapper.Logger(dynamic.Logger))
+		argmapper.Logger(dynamic.Logger),
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -134,6 +135,7 @@ func Func(s *vagrant_plugin_sdk.FuncSpec, cb interface{}, args ...argmapper.Arg)
 		return nil
 	}, append([]argmapper.Arg{
 		argmapper.ConverterGen(anyConvGen),
+		argmapper.FuncName(s.Name),
 	}, args...)...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
    Provides a custom name for the any converters that are created
    automatically. It also sets the func name from the name value
    defined in the spec. This reduces the occurrence of functions
    showing up in the argmapper error output with `reflect.makeFuncStub`
    names.
