### PR TITLE
internal/pkg/conpty: only build on windows

### DIFF
--- a/internal/pkg/conpty/conpty.go
+++ b/internal/pkg/conpty/conpty.go
@@ -1,3 +1,5 @@
+// +build windows
+
 // Original copyright 2020 ActiveState Software. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file

--- a/internal/pkg/conpty/syscall.go
+++ b/internal/pkg/conpty/syscall.go
@@ -1,3 +1,5 @@
+// +build windows
+
 // Copyright 2020 ActiveState Software. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file


### PR DESCRIPTION
Mirrors
https://github.com/hashicorp/waypoint-plugin-sdk/pull/18/commits/742b267e984fc2924242e439f0bfefccfa7fe86e
and prevents `go test -v ./...` from failing on non-windows machines
with `imports golang.org/x/sys/windows: build constraints exclude all Go files`