### PR TITLE
Include options in synced folder map

### DIFF
--- a/internal-shared/protomappers/mappers.go
+++ b/internal-shared/protomappers/mappers.go
@@ -1370,7 +1370,10 @@ func FolderToVagrantfileSyncedFolder(
 	f *core.Folder,
 ) (*vagrant_plugin_sdk.Vagrantfile_SyncedFolder, error) {
 	var result *vagrant_plugin_sdk.Vagrantfile_SyncedFolder
-	return result, mapstructure.Decode(f, &result)
+	err := mapstructure.Decode(f.Options, &result)
+	result.Source = f.Source
+	result.Destination = f.Destination
+	return result, err
 }
 
 func SyncedFolderProto(


### PR DESCRIPTION
This PR fixes the synced folder mapper so that the synced folder options also get mapped