### PR TITLE
Move Vagrant's temp file location to a larger base dir

### DIFF
--- a/helper/paths/paths.go
+++ b/helper/paths/paths.go
@@ -72,13 +72,13 @@ func VagrantTmp() (path.Path, error) {
 	if ok {
 		val = path.NewPath(v)
 	} else {
-		v = xdg.RuntimeDir
+		v = xdg.CacheHome
 		if _, err := os.Stat(v); err != nil {
 			if v, err = ioutil.TempDir("", "vagrant-tmp"); err != nil {
 				return nil, err
 			}
 		}
-		val = path.NewPath(v).Join("vagrant")
+		val = path.NewPath(v).Join("vagrant-tmp")
 	}
 
 	return setupPath(val)


### PR DESCRIPTION
Vagrant's TempDir location was defaulting to use XDG_RUNTIME_DIR.
According to the spec:

> Applications should use this directory for communication and
> synchronization purposes and should not place larger files in it, since
> it might reside in runtime memory and cannot necessarily be swapped out
> to disk.

https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables

This is indeed a small ramdisk (e.g. `/var/run/1000`) in some
systemd-based Linux environments, and would routinely run out of space
when Vagrant used the location for staging box file operations.

I think the closest XDG location to use instead is another dir within
XDG_CACHE_HOME, which is defined as being for "user-specific
non-essential data files".