### PR TITLE
Keep temporary file path consistent

### DIFF
--- a/helper/paths/paths.go
+++ b/helper/paths/paths.go
@@ -4,7 +4,6 @@ package paths
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/adrg/xdg"
@@ -72,13 +71,11 @@ func VagrantTmp() (path.Path, error) {
 	if ok {
 		val = path.NewPath(v)
 	} else {
-		v = xdg.CacheHome
-		if _, err := os.Stat(v); err != nil {
-			if v, err = ioutil.TempDir("", "vagrant-tmp"); err != nil {
-				return nil, err
-			}
+		var err error
+		if val, err = VagrantCache(); err != nil {
+			return nil, err
 		}
-		val = path.NewPath(v).Join("vagrant-tmp")
+		val = val.Join("tmp")
 	}
 
 	return setupPath(val)


### PR DESCRIPTION
    This makes a couple more adjustments to the temporary directory
    setup. It uses the `VagrantCache()` path so if a user has provided
    a custom cache location, the temporary directory path will respect
    the custom location. It also removes the temporary directory
    name creation and instead uses a constant string value. By using
    a constant value the files in the temporary directory can be
    referenced by subsequent runs (which allows for things like
    restarting failed downloads).
