### PR TITLE
Add seeder interface to guest core component

### DIFF
--- a/component/mocks/SyncedFolder.go
+++ b/component/mocks/SyncedFolder.go
@@ -89,6 +89,22 @@ func (_m *SyncedFolder) HasCapabilityFunc() interface{} {
 	return r0
 }
 
+// PrepareFunc provides a mock function with given fields:
+func (_m *SyncedFolder) PrepareFunc() interface{} {
+	ret := _m.Called()
+
+	var r0 interface{}
+	if rf, ok := ret.Get(0).(func() interface{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(interface{})
+		}
+	}
+
+	return r0
+}
+
 // UsableFunc provides a mock function with given fields:
 func (_m *SyncedFolder) UsableFunc() interface{} {
 	ret := _m.Called()

--- a/core/guest.go
+++ b/core/guest.go
@@ -6,6 +6,7 @@ import (
 
 type Guest interface {
 	CapabilityPlatform
+	Seeder
 
 	Detect(Target) (bool, error)
 	Parent() (string, error)

--- a/core/mocks/Guest.go
+++ b/core/mocks/Guest.go
@@ -114,3 +114,40 @@ func (_m *Guest) Parent() (string, error) {
 
 	return r0, r1
 }
+
+// Seed provides a mock function with given fields: _a0
+func (_m *Guest) Seed(_a0 *core.Seeds) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*core.Seeds) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Seeds provides a mock function with given fields:
+func (_m *Guest) Seeds() (*core.Seeds, error) {
+	ret := _m.Called()
+
+	var r0 *core.Seeds
+	if rf, ok := ret.Get(0).(func() *core.Seeds); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Seeds)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/core/mocks/Named.go
+++ b/core/mocks/Named.go
@@ -9,8 +9,8 @@ type Named struct {
 	mock.Mock
 }
 
-// GetPluginName provides a mock function with given fields:
-func (_m *Named) GetPluginName() (string, error) {
+// PluginName provides a mock function with given fields:
+func (_m *Named) PluginName() (string, error) {
 	ret := _m.Called()
 
 	var r0 string

--- a/core/mocks/SyncedFolder.go
+++ b/core/mocks/SyncedFolder.go
@@ -110,6 +110,23 @@ func (_m *SyncedFolder) HasCapability(name string) (bool, error) {
 	return r0, r1
 }
 
+// Prepare provides a mock function with given fields: machine, folders, opts
+func (_m *SyncedFolder) Prepare(machine core.Machine, folders []*core.Folder, opts ...interface{}) error {
+	var _ca []interface{}
+	_ca = append(_ca, machine, folders)
+	_ca = append(_ca, opts...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(core.Machine, []*core.Folder, ...interface{}) error); ok {
+		r0 = rf(machine, folders, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Usable provides a mock function with given fields: machine
 func (_m *SyncedFolder) Usable(machine core.Machine) (bool, error) {
 	ret := _m.Called(machine)


### PR DESCRIPTION
This is required for tests on the vagrant side to assert that
a core.Guest also supports the seeder interface