### PR TITLE
Port over https://github.com/hashicorp/waypoint-plugin-sdk/pull/30

### DIFF
--- a/internal/plugin/terminal/ui.go
+++ b/internal/plugin/terminal/ui.go
@@ -318,6 +318,13 @@ func (u *uiBridge) Close() error {
 	defer u.mu.Unlock()
 
 	err := u.evc.CloseSend()
+	
+	// The remote side never sends anything back to us, so this will just wait
+	// until the remote side has seen our closure and the stream has been
+	// closed. We don't actually care if there is an error here, just that
+	// we did wait.
+	u.evc.Recv()
+	
 	u.evc = nil
 	u.cancel()
 


### PR DESCRIPTION
Hi friends! I see that you might have a UI bug where you lose messages. We (waypoint team) see you attempting to work around it by doing interlocking messages on the stream. We hit this issue and use this to solve the issue, which keeps the client from exiting before the server has seen all the data.