### PR TITLE
Don't double close a grpc client

### DIFF
--- a/internal-shared/protomappers/mappers.go
+++ b/internal-shared/protomappers/mappers.go
@@ -3,7 +3,6 @@ package protomappers
 import (
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"reflect"
 	"strings"
@@ -2834,10 +2833,6 @@ func wrapConnect(
 			"error", err)
 
 		return nil, err
-	}
-
-	if closer, ok := client.(io.Closer); ok {
-		internal.Cleanup().Do(func() error { return closer.Close() })
 	}
 
 	if cache, ok := client.(cacher.HasCache); ok {


### PR DESCRIPTION
The `box remove` command hangs when it's trying to close all the plugins. This happens because the closers acquire a mutex when closing. There are some closers that are called multiple times within other closers causing the same mutex to be locked. Go will hang until the mutex becomes available, which will never happen in this case.

To test this run a `vagrant box remove hashicorp/bionic64`. This command should not hang.