### PR TITLE
Setup new cleanups when creating new clients, servers and when wrapping plugins

### DIFF
--- a/internal/plugin/base.go
+++ b/internal/plugin/base.go
@@ -102,7 +102,7 @@ func (b *BasePlugin) NewClient(
 		Base: &Base{
 			Broker:  broker,
 			Cache:   b.Cache,
-			Cleanup: b.Cleanup,
+			Cleanup: cleanup.New(),
 			Logger:  b.Logger,
 			Mappers: mappers(b.Mappers),
 			Wrapped: b.Wrapped,
@@ -122,7 +122,7 @@ func (b *BasePlugin) NewServer(
 		Base: &Base{
 			Broker:  broker,
 			Cache:   b.Cache,
-			Cleanup: b.Cleanup,
+			Cleanup: cleanup.New(),
 			Logger:  b.Logger,
 			Mappers: mappers(b.Mappers),
 			Wrapped: b.Wrapped,
@@ -148,7 +148,7 @@ type Base struct {
 func (b *Base) Wrap() *BasePlugin {
 	return &BasePlugin{
 		Cache:   b.Cache,
-		Cleanup: b.Cleanup,
+		Cleanup: cleanup.New(),
 		Logger:  b.Logger,
 		Mappers: mappers(b.Mappers),
 		Wrapped: true,


### PR DESCRIPTION
Previously, there were some cases where a cleanup action would
call cleanup on itself. This caused the cleanup mutex to be locked
multiple times, resulting in Vagrant hanging waiting for the mutex
to become available.

This resolves the issue where Vagrant hangs when trying to remove a box. To test this out run `vagrant box remove MYBOX` and observe that Vagrant successfully removes the box and exits.