### PR TITLE
Don't add new line to output if disabled

### DIFF
--- a/internal/plugin/terminal/ui.go
+++ b/internal/plugin/terminal/ui.go
@@ -168,7 +168,11 @@ func (s *uiServer) Events(stream vagrant_plugin_sdk.TerminalUIService_EventsServ
 
 		switch ev := ev.Event.(type) {
 		case *vagrant_plugin_sdk.TerminalUI_Event_Line_:
-			s.Impl.Output(ev.Line.Msg, terminal.WithStyle(ev.Line.Style))
+			if ev.Line.DisableNewLine {
+				s.Impl.Output(ev.Line.Msg, terminal.WithStyle(ev.Line.Style), terminal.WithoutNewLine())
+			} else {
+				s.Impl.Output(ev.Line.Msg, terminal.WithStyle(ev.Line.Style))
+			}
 			stream.Send(&vagrant_plugin_sdk.TerminalUI_Response{
 				Event: &vagrant_plugin_sdk.TerminalUI_Response_Input{
 					Input: &vagrant_plugin_sdk.TerminalUI_Event_InputResp{


### PR DESCRIPTION
This resolves https://github.com/hashicorp/vagrant/issues/12868. Now when running a `global-status` the output is in table form

```
 % ./vagrant global-status


  id         name     provider     state         directory                             
  ---------------------------------------------------------------------------
  1734202    one      virtualbox   not_created   /Users/sophia/project/vagrant         
  cb8a0b6    two      virtualbox   not_created   /Users/sophia/project/vagrant         
   
  The above shows information about all known Vagrant environments
  on this machine. This data is cached and may not be completely
  up-to-date (use "vagrant global-status --prune" to prune invalid
  entries). To interact with any of the machines, you can go to that
  directory and run Vagrant, or you can use the ID directly with
  Vagrant commands from any directory. For example:
  "vagrant destroy 1a2b3c4d"
```