### PR TITLE
Don't output secret text

### DIFF
--- a/terminal/glint.go
+++ b/terminal/glint.go
@@ -105,8 +105,8 @@ func (ui *glintUI) Input(input *Input) (line string, err error) {
 	}
 
 	text := strings.TrimSpace(line)
-	if !input.Secret {
-		ui.Output(text)
+	if input.Secret {
+		ui.Output("")
 	} else {
 		ui.Output(text)
 	}


### PR DESCRIPTION
Fixes typo in https://github.com/hashicorp/vagrant-plugin-sdk/pull/188 in particular [here](https://github.com/hashicorp/vagrant-plugin-sdk/pull/188/files#diff-e3464f1cb42225f8a22a25b170f5a85216677fa8bb3ded98fd709e37391241c0R111) (where the secret output is written to the terminal).